### PR TITLE
Bug 1160962 - [gaia-list] active effect length is short, can't full fill width size when tap at the edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Email style list (with time stamp)
 </gaia-list>
 ```
 
+### ripple
+
+Put `ripple` in class list will force trigger the ripple effect.
+
+Put `a` href in content will trigger the ripple effect automatically.
+
+Put `no-ripple` in class list will force NOT trigger the ripple effect.
+
 ### flexbox
 
 Defines the element as a `display: flex`.

--- a/bower.json
+++ b/bower.json
@@ -12,16 +12,19 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "index.html",
+    "package.json",
+    "README.md"
   ],
   "devDependencies": {
     "base": "gaia-components/base",
-    "gaia-fonts": "gaia-components/gaia-fonts#~0.2.1",
-    "gaia-icons": "gaia-components/gaia-icons#~0.6.1",
+    "gaia-fonts": "gaia-components/gaia-fonts",
+    "gaia-icons": "gaia-components/gaia-icons",
     "gaia-switch": "gaia-components/gaia-switch",
-    "gaia-theme": "gaia-components/gaia-theme#dev"
+    "gaia-theme": "gaia-components/gaia-theme"
   },
   "dependencies": {
-    "gaia-component": "gaia-components/gaia-component#~0.3.6"
+    "gaia-component": "gaia-components/gaia-component#^0.3.6"
   }
 }

--- a/gaia-list.js
+++ b/gaia-list.js
@@ -25,6 +25,8 @@ var pointer = [
  */
 
 module.exports = component.register('gaia-list', {
+  extends: HTMLUListElement.prototype,
+
   created: function() {
     this.setupShadowRoot();
     this.els = { inner: this.shadowRoot.querySelector('.inner') };
@@ -62,6 +64,10 @@ module.exports = component.register('gaia-list', {
       ripple: document.createElement('div')
     };
 
+    requestAnimationFrame(this.ripple.bind(this, point, pos, els));
+  },
+
+  ripple: function(point, pos, els) {
     els.container.className = 'ripple-container';
     els.container.style.left = (pos.item.left - pos.list.left) + 'px';
     els.container.style.top = (pos.item.top - pos.list.top) + 'px';
@@ -81,13 +87,11 @@ module.exports = component.register('gaia-list', {
     els.container.appendChild(els.ripple);
     this.els.inner.appendChild(els.container);
 
-    // var reflow = els.ripple.offsetTop;
-    var scale = pos.item.width / 1.2;
     var duration = 500;
 
     setTimeout(function() {
       els.ripple.style.visibility = '';
-      els.ripple.style.transform = 'scale(' + scale + ')';
+      els.ripple.style.transform = 'scale(' + pos.item.width + ')';
       els.ripple.style.transitionDuration = duration  + 'ms';
       setTimeout(function() {
         els.ripple.style.transitionDuration = '1000ms';

--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
   <link rel="stylesheet" type="text/css" href="bower_components/base/base.css">
   <link rel="stylesheet" type="text/css" href="bower_components/gaia-theme/gaia-theme.css">
   <link rel="stylesheet" type="text/css" href="bower_components/gaia-fonts/style.css">
-  <link rel="stylesheet" type="text/css" href="bower_components/gaia-icons/style.css">
   <script src="bower_components/gaia-theme/lib/gaia-theme-selector.js"></script>
   <script src="bower_components/gaia-icons/gaia-icons.js"></script>
   <script src="bower_components/gaia-component/gaia-component.js"></script>
+  <script src="bower_components/drag/drag.js"></script>
   <script src="bower_components/gaia-switch/gaia-switch.js"></script>
   <script src="gaia-list.js"></script>
   <style type="text/css">
@@ -52,6 +52,11 @@
       background: var(--background-plus);
     }
 
+    [dir=rtl] gaia-list.contacts .face {
+      left: 16px;
+      right: auto;
+    }
+
     gaia-list.email > * {
       padding-left: 32px !important;
     }
@@ -62,6 +67,11 @@
       margin: 9px 16px;
       font-size: 0.7em;
       opacity: 0.6;
+    }
+
+    [dir=rtl] gaia-list.email time {
+      left: 0;
+      right: auto;
     }
 
     gaia-list.email p {
@@ -82,6 +92,10 @@
         var(--highlight-color);
     }
 
+    [dir=rtl] gaia-list.email .unread:after {
+      left: auto;
+      right: 0;
+    }
 
   </style>
 </head>


### PR DESCRIPTION
* with 1st animation approach discussed in bugzilla
*  update bower to compatible with 0.3+ gaia-component, no need change until pump gaia-component to 0.4+
* use `requestAnimationFrame` instead of `setTimeout` to boost animation performance
* add RTL treatment for example
* add `ripple` usage in README