### PR TITLE
use transitionend event to make sure doing actions when a CSS transition has completed

### DIFF
--- a/gaia-list.js
+++ b/gaia-list.js
@@ -87,19 +87,22 @@ module.exports = component.register('gaia-list', {
     els.container.appendChild(els.ripple);
     this.els.inner.appendChild(els.container);
 
-    var duration = 500;
-
-    setTimeout(function() {
+    var end = 'transitionend';
+    requestAnimationFrame(function() {
       els.ripple.style.visibility = '';
       els.ripple.style.transform = 'scale(' + pos.item.width + ')';
-      els.ripple.style.transitionDuration = duration  + 'ms';
-      setTimeout(function() {
+      els.ripple.style.transitionDuration = '500ms';
+
+      els.ripple.addEventListener(end, function fn() {
+        els.ripple.removeEventListener(end, fn);
         els.ripple.style.transitionDuration = '1000ms';
         els.ripple.style.opacity = '0';
-        setTimeout(function() {
+
+        els.ripple.addEventListener(end, function fn() {
+          els.ripple.removeEventListener(end, fn);
           els.container.remove();
-        }, 1000);
-      }, duration);
+        });
+      });
     });
   },
 


### PR DESCRIPTION
It's always better not use setTimeout to do animations. 

* perf: the stress.html test shows same time (130xms) after patch.

Ref: http://samcroft.co.uk/2013/css-transition-event-control/
